### PR TITLE
Fixes #22

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -9,9 +9,10 @@ ENV OVA=https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-am
 
 RUN apk update && apk add --virtual build-dependencies curl git bash jq openssh rsync py-pip python python-dev libffi-dev openssl-dev build-base && \
     pip install --upgrade pip && \
-    pip install ansible && \
+    pip install 'ansible<2.6' && \
     curl -L $OVA -o /bootstrap.ova && \
     curl -L $GOVC | gunzip > /usr/bin/govc && chmod +x /usr/bin/govc
+
 COPY . /
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/bootstrap/Dockerfile.testing
+++ b/bootstrap/Dockerfile.testing
@@ -12,7 +12,7 @@ RUN apt-get -qq update && apt-get install -y \
 		sudo && \
     curl -L $GOVC | gunzip > /usr/bin/govc && chmod +x /usr/bin/govc && \
 	useradd -ms /bin/bash vmware && \
-	pip install ansible==2.5.5 && \
+	pip install 'ansible<2.6' && \
 	echo 'vmware ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/vmware
 
 COPY . /home/vmware


### PR DESCRIPTION
This commit pins Ansible to the most recent version before 2.6
to overcome get_url bugs introduced in that version. When fixes
arrive for those, this will be reverted.

Signed-off-by: Tom Hite <tdhite@vmware.com>