### PR TITLE
Add automated reload of pipelines.

### DIFF
--- a/bootstrap/Dockerfile.testing
+++ b/bootstrap/Dockerfile.testing
@@ -28,5 +28,9 @@ RUN ansible-galaxy install -r external_roles.yml && \
 	ssh-keygen -f ~/.ssh/id_rsa.test -t rsa -N '' && \
 	echo "---" > ~/.ansible/roles/concourse/tasks/kernel_update.yml
 
-CMD ["-vv", "-e", "do_download=false", "-e", "ansible_ssh_user=root", "-e", "ansible_ssh_private_key_file=~/.ssh/id_rsa.test", "-e", "bootstrap_box_ip=localhost", "site.yml", "-i", "inventory"]
+CMD ["-vv", "-e", "do_download=false", "-e", "ansible_ssh_user=root", \
+"-e", "ansible_ssh_private_key_file=~/.ssh/id_rsa.test", \
+"-e", "bootstrap_box_ip=localhost", \
+"-e", "deploy_user=vmware", \
+"site.yml", "-i", "inventory"]
 ENTRYPOINT [ "ansible-playbook" ]

--- a/bootstrap/provision/concourse.yml
+++ b/bootstrap/provision/concourse.yml
@@ -36,3 +36,27 @@
       become: True
       command: iptables -I FORWARD -j ACCEPT
       when: iptables_stat.stat.exists
+# Deploy automation to repload the pipelines on change.
+    - name: Copy automation to reload pipelines
+      become: True
+      copy:
+        src: refly
+        dest: /home/{{ deploy_user }}
+        owner: "{{ deploy_user }}"
+    - name: Need cron
+      apt: pkg=cron state=present
+    - name: Debug
+      debug: msg="concourse_web_options.CONCOURSE_BASIC_AUTH_USERNAME {{ concourse_web_options.CONCOURSE_BASIC_AUTH_USERNAME }}"
+    - name: Save vars to future runs
+      template:
+        src: refly/templates/extra_vars.yml.j2
+        dest: /home/{{ deploy_user }}/refly/extra_vars.yml
+    - name: Setup cron job
+      become: True
+      cron:
+        name: "Refly Concourse Pipelines"
+        minute: "*/2"
+        job: >-
+          cd $HOME/refly &&
+          ansible-playbook -i inventory site.yml -e "@extra_vars.yml"
+        user: "{{ deploy_user }}"

--- a/bootstrap/provision/concourse.yml
+++ b/bootstrap/provision/concourse.yml
@@ -36,27 +36,31 @@
       become: True
       command: iptables -I FORWARD -j ACCEPT
       when: iptables_stat.stat.exists
-# Deploy automation to repload the pipelines on change.
+# Deploy automation to load/reload the pipelines on change.
     - name: Copy automation to reload pipelines
-      become: True
       copy:
         src: refly
         dest: /home/{{ deploy_user }}
         owner: "{{ deploy_user }}"
-    - name: Need cron
+    - name: Need cron for refly
       apt: pkg=cron state=present
-    - name: Debug
-      debug: msg="concourse_web_options.CONCOURSE_BASIC_AUTH_USERNAME {{ concourse_web_options.CONCOURSE_BASIC_AUTH_USERNAME }}"
     - name: Save vars to future runs
       template:
         src: refly/templates/extra_vars.yml.j2
         dest: /home/{{ deploy_user }}/refly/extra_vars.yml
-    - name: Setup cron job
-      become: True
+    - name: Ensure /usr/local/bin is in crontab PATH
+      cron:
+        name: PATH
+        env: yes
+        value: "$HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        user: "{{ deploy_user }}"
+    - name: Setup refly cron job
       cron:
         name: "Refly Concourse Pipelines"
         minute: "*/2"
         job: >-
           cd $HOME/refly &&
-          ansible-playbook -i inventory site.yml -e "@extra_vars.yml"
+          ansible-playbook -i inventory site.yml
+          -e "@extra_vars.yml"
+          -vv >> refly.lastlog 2>&1
         user: "{{ deploy_user }}"

--- a/bootstrap/provision/refly/group_vars/concourse-web/vars.yml
+++ b/bootstrap/provision/refly/group_vars/concourse-web/vars.yml
@@ -1,0 +1,3 @@
+concourse_host: localhost
+councourse_web_user: vmware
+councourse_web_password: PASSED_IN_AS_EXVARS

--- a/bootstrap/provision/refly/inventory
+++ b/bootstrap/provision/refly/inventory
@@ -1,0 +1,2 @@
+[concourse-web]
+localhost        ansible_connection=local

--- a/bootstrap/provision/refly/pipeline.yml
+++ b/bootstrap/provision/refly/pipeline.yml
@@ -1,0 +1,105 @@
+# Examine and load or reload a potential pipeline
+---
+- name: debug
+  debug:
+    msg: "Checking pipeline {{ pipeline_stat.path | basename }} for freshness"
+
+- name: Check for existing pipeline checksum
+  stat:
+    path: "/tmp/{{ pipeline_stat.path | basename }}.checksum"
+  register: pipelines_checksum_stat
+
+# handle an existing pipeline checksum
+- block:
+    - name: Read pipeline checksum
+      command: cat "/tmp/{{ pipeline_stat.path | basename }}.checksum"
+      register: previous_checksum
+
+    - name: Set pipelines checksum
+      set_fact: previous_checksum="{{ previous_checksum.stdout }}"
+
+  when: pipelines_checksum_stat.stat.exists
+
+- name: Write to pipeline checksum
+  copy:
+    content: "{{ pipeline_stat.checksum }}"
+    dest: "/tmp/{{ pipeline_stat.path | basename }}.checksum"
+  when: not pipelines_checksum_stat.stat.exists or
+        (pipelines_checksum_stat.stat.exists and
+         previous_checksum != pipeline_stat.checksum)
+  register: updated_file
+
+- name: Super simple check for whether the file is a pipeline definition
+  shell: cat "{{ pipeline_stat.path }}" | grep -e "^jobs:$"
+  when:
+    - updated_file.changed
+  register: have_pipeline
+  failed_when: have_pipeline.rc > 1 or have_pipeline.rc < 0
+
+# If we don't have a pipeline, expect that this is a params file.
+# The convention is {pipeline}-params.yml
+- block:
+    - name: Set expected pipeline name from params file
+      set_fact:
+        expected_pipeline: >-
+          {{ pipeline_stat.path |
+             regex_replace('^(.*)-params.yml$', '\1.yml') }}
+    - name: Check for expected pipeline by computed name
+      stat:
+        path: "{{ expected_pipeline }}"
+      register: now_have_pipeline
+    - name: Now we have the pipeline we need
+      set_fact:
+        pipeline_def: "{{ expected_pipeline }}"
+      when: now_have_pipeline is defined and now_have_pipeline.stat.exists
+    - name: Now we have the params we need
+      set_fact:
+        pipeline_params: "{{ pipeline_stat.path }}"
+  when: have_pipeline.changed and have_pipeline.rc > 0 and updated_file.changed
+
+# If we do have a pipeline, look for the matching params file.
+# The convention is {pipeline}-params.yml
+- block:
+    - name: Set the pipeline name
+      set_fact:
+        pipeline_def: "{{ pipeline_stat.path }}"
+    - name: Set expected params file from pipeline name
+      set_fact:
+        expected_params: >-
+          {{ pipeline_stat.path |
+             regex_replace('^(.*).yml$', '\1-params.yml') }}
+    - name: Check for expected params by computed name
+      stat:
+        path: "{{ expected_params }}"
+      register: now_have_params
+    - name: Now we have the params we need
+      set_fact:
+        pipeline_params: "{{ expected_params }}"
+      when: now_have_params is defined and now_have_params.stat.exists
+    - name: Now we have the pipeline we need
+      set_fact:
+        pipeline_def: "{{ pipeline_stat.path }}"
+  when: have_pipeline.changed and have_pipeline.rc == 0 and updated_file.changed
+
+- name: Rerun fly command
+  block:
+    - debug:
+        msg: "RELOAD PIPELINE {{ pipeline_def }} with params {{ pipeline_params }}"
+    - name: Login to concourse
+      command: >
+        fly --target main login -c http://{{ concourse_host }}:8080
+        -u {{ concourse_web_user }} -p '{{ concourse_web_password }}'
+    - name: Upload pipeline definition
+      command: >
+        fly -t main set-pipeline -n
+        -p {{ (pipeline_def | basename | splitext)[0] }}
+        -c {{ pipeline_def }}
+        -l {{ pipeline_params }}
+    - name: Unpause pipeline
+      command: >
+        fly -t main unpause-pipeline
+        -p {{ (pipeline_def | basename | splitext)[0] }}
+  when:
+    - have_pipeline.changed
+    - pipeline_def is defined
+    - pipeline_params is defined

--- a/bootstrap/provision/refly/site.yml
+++ b/bootstrap/provision/refly/site.yml
@@ -1,0 +1,26 @@
+---
+- name: Continuously refresh the concourse pipelines
+  hosts: concourse-web
+  become: False
+  tasks:
+    - name: Set default pipelines directory
+      set_fact: pipelines_home="{{ ansible_env.HOME }}/deployroot/pipelines"
+
+    - name: Check for pipelines
+      stat: path="{{ pipelines_home }}"
+      register: pipelines_stat
+
+    - name: Get all pipelines
+      stat:
+        path: "{{ item }}"
+        follow: True
+      register: all_pipelines_stats
+      with_fileglob: "{{ pipelines_home }}/*.yml"
+      when: pipelines_stat.stat.exists
+
+    - name: Iterate over pipelines
+      include_tasks: pipeline.yml
+      loop: "{{ all_pipelines_stats.results|map(attribute='stat')|list }}"
+      loop_control:
+        loop_var: pipeline_stat
+      when: all_pipelines_stats.results is defined

--- a/bootstrap/provision/refly/templates/extra_vars.yml.j2
+++ b/bootstrap/provision/refly/templates/extra_vars.yml.j2
@@ -1,0 +1,3 @@
+concourse_host: localhost
+concourse_web_user: {{ concourse_web_options.CONCOURSE_BASIC_AUTH_USERNAME }}
+concourse_web_password: {{ concourse_web_options.CONCOURSE_BASIC_AUTH_PASSWORD }}


### PR DESCRIPTION
This deploys code that will automatically load the initial version of concourse pipelines, and will reload them on any change.

This relies on:
* pipeline definition and params files exist at ~/deployroot/pipelines
* pipeline params are named the same as the pipeline with -params, for example "nsx-install.yml" and "nsx-install-params.yml"
* it's a cron job that runs every 2 minutes, so there's up to a 2 minute delay before new pipeline definition is loaded. 