### PR TITLE
Parameterize deployroot for non-Docker use. Add script usage, add copyonly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - stage: test-bootstrap-provision
       script:
         - docker build -t bootstrap -f Dockerfile.testing .
-        - docker run -v -v $PWD/..:/deployroot/pks-deploy bootstrap
+        - docker run -v $PWD/..:/deployroot/pks-deploy bootstrap
     - stage: build-bootstrap
       script:
         - docker build -t vmware/pks-deploy:bootstrap .

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     - stage: test-bootstrap-provision
       script:
         - docker build -t bootstrap -f Dockerfile.testing .
-        - docker run bootstrap
+        - docker run -v -v $PWD/..:/deployroot/pks-deploy bootstrap
     - stage: build-bootstrap
       script:
         - docker build -t vmware/pks-deploy:bootstrap .

--- a/bootstrap/Dockerfile.testing
+++ b/bootstrap/Dockerfile.testing
@@ -21,6 +21,7 @@ RUN chown -R vmware:vmware /home/vmware
 # This isn't really needed for purely testing the automation
 # ADD $OVA /bootstrap.ova
 
+RUN mkdir -p /deployroot
 WORKDIR /home/vmware/provision
 USER vmware
 

--- a/bootstrap/provision/download.yml
+++ b/bootstrap/provision/download.yml
@@ -11,7 +11,9 @@
         group: "{{ minio_group }}"
         mode: 0775
     - name: Run download script
-      script: "/deployroot/pks-deploy/downloads/download.sh {{ download_dir }}/{{ download_bucket }}"
+      script: >-
+        {{ deployroot }}/{{ solution_name }}-deploy/downloads/download.sh
+        {{ download_dir }}/{{ download_bucket }}
       environment:
        PIVNET_API_TOKEN: "{{ pivnet_api_token }}"
        MY_VMWARE_USER: "{{ my_vmware_user }}"

--- a/bootstrap/provision/group_vars/bootstrap/vars.yml
+++ b/bootstrap/provision/group_vars/bootstrap/vars.yml
@@ -7,6 +7,8 @@ ovf_zip_checksum: "sha256:d327c8c7ebaac7432a589b1207410889d00c1ffd3fe18fa751b144
 do_download: false
 download_dir: "/downloads"
 download_bucket: "pks"
+deploy_user: "vmware"
+deployroot: "/deployroot"
 
 minio_server_datadirs: [ "{{ download_dir }}" ]
 minio_access_key: "vmware"

--- a/bootstrap/provision/group_vars/bootstrap/vars.yml
+++ b/bootstrap/provision/group_vars/bootstrap/vars.yml
@@ -9,6 +9,7 @@ download_dir: "/downloads"
 download_bucket: "pks"
 deploy_user: "vmware"
 deployroot: "/deployroot"
+solution_name: "pks"
 
 minio_server_datadirs: [ "{{ download_dir }}" ]
 minio_access_key: "vmware"

--- a/bootstrap/provision/site.yml
+++ b/bootstrap/provision/site.yml
@@ -13,4 +13,4 @@
 - import_playbook: utilities.yml
 
 - import_playbook: download.yml
-  when: do_download is defined and do_download == true
+  when: do_download is defined and do_download

--- a/bootstrap/provision/site.yml
+++ b/bootstrap/provision/site.yml
@@ -13,4 +13,4 @@
 - import_playbook: utilities.yml
 
 - import_playbook: download.yml
-  when: do_download is defined and do_download
+  when: do_download is defined and do_download|bool


### PR DESCRIPTION
Signed-off-by: John Gardner <huxoll@gmail.com>

-c for copyonly, skips the entire provision step.  For example, change params file, run with copyonly to update the pipeline file, then the "refly" automation will reload the pipeline.
