### PR TITLE
download: always build downloads directory

### DIFF
--- a/bootstrap/Dockerfile.testing
+++ b/bootstrap/Dockerfile.testing
@@ -6,6 +6,7 @@ ENV ANSIBLE_HOST_KEY_CHECKING=False
 
 RUN apt-get -qq update && apt-get install -y \
 		curl \
+		jq \
 		git \
 		openssh-server \
 		python-pip \

--- a/bootstrap/provision/download.yml
+++ b/bootstrap/provision/download.yml
@@ -19,5 +19,3 @@
         MY_VMWARE_USER: "{{ my_vmware_user }}"
         MY_VMWARE_PASSWORD: "{{ my_vmware_password }}"
       when: do_download is defined and do_download|bool
-    - name: set minio download access for /download/pks
-      shell: mc policy download local/{{ download_bucket }}

--- a/bootstrap/provision/download.yml
+++ b/bootstrap/provision/download.yml
@@ -18,5 +18,6 @@
         PIVNET_API_TOKEN: "{{ pivnet_api_token }}"
         MY_VMWARE_USER: "{{ my_vmware_user }}"
         MY_VMWARE_PASSWORD: "{{ my_vmware_password }}"
+      when: do_download is defined and do_download|bool
     - name: set minio download access for /download/pks
-      shell: mc policy local/{{ download_bucket }} download
+      shell: mc policy download local/{{ download_bucket }}

--- a/bootstrap/provision/fileshare.yml
+++ b/bootstrap/provision/fileshare.yml
@@ -12,14 +12,3 @@
         mode: 0775
   roles:
     - minio
-  post_tasks:
-    - name: create mc configuration directory
-      file:
-        state: directory
-        path: "~/.mc"
-        mode: 0755
-    - name: create mc configuration file
-      template:
-        src: templates/mc/config.json
-        dest: "~/.mc/config.json"
-        mode: 0600

--- a/bootstrap/provision/site.yml
+++ b/bootstrap/provision/site.yml
@@ -11,6 +11,4 @@
 - import_playbook: concourse.yml
 - import_playbook: fileshare.yml
 - import_playbook: utilities.yml
-
 - import_playbook: download.yml
-  when: do_download is defined and do_download|bool

--- a/bootstrap/user-data.yml
+++ b/bootstrap/user-data.yml
@@ -33,6 +33,7 @@ ntp:
   enabled: true
 packages:
   - curl
+  - jq
   - docker.io
   - open-vm-tools
   - python-setuptools

--- a/downloads/download.sh
+++ b/downloads/download.sh
@@ -3,6 +3,9 @@
 # first arg is the directory to put files
 cd $1
 
+# Where is the default minio config-folder
+MINIO_CONFIG="~minio/.minio"
+
 if [[ -z "$PIVNET_API_TOKEN" ]]; then
     echo "Must provide a Pivotal Network API_TOKEN in environment" 1>&2
     exit 1
@@ -25,3 +28,20 @@ docker run -v ${PWD}:/vmwfiles apnex/myvmw get nsx-edge-2.1.0.0.0.7395502.ova
 pivnet-cli login --api-token $PIVNET_API_TOKEN
 pivnet-cli download-product-files -p ops-manager -r 2.1.5 -g '*vsphere*'
 pivnet-cli download-product-files -p pivotal-container-service -r 1.0.4 -g '*pks-linux*'
+
+# Set download permisions on the download directory
+# This gyration is needed to to overcome testing problems with minio
+# not getting set with the right credentials.
+tmpdir=/tmp/$(mktemp -u XXXXXXXX)
+mkdir -p ${tmpdir}
+chmod 0755 ${tmpdir}
+sudo su -c "cat ~minio/.minio/config.json >${tmpdir}/config.json.tmp"
+sudo su -c "chmod 644 ${tmpdir}/config.json.tmp"
+minio_accessKey=$(sudo su -c "jq -r .credential.accessKey ${tmpdir}/config.json.tmp")
+minio_secretKey=$(sudo su -c "jq -r .credential.secretKey ${tmpdir}/config.json.tmp")
+set | grep minio
+mc --config-folder ${tmpdir} config host add local 'http://localhost:9091' "${minio_accessKey}" "${minio_secretKey}" S3v4
+sudo su -c "chmod 0644 ${tmpdir}/config.json"
+sudo su -c "chmod 0755 ${tmpdir}/certs"
+mc --config-folder ${tmpdir} policy download local/${PWD##*/}
+rm -rf ${tmpdir}


### PR DESCRIPTION
If downloads is turned off, the directory is never created for minio uploads (or otherwise placement of the files manually). The directory should always exist and be setup for http download access.

Signed-off-by: Tom Hite <thite@vmware.com>