### PR TITLE
Generate a dynamic pipeline with tasks in swimlanes.

### DIFF
--- a/bootstrap/provision/refly/pipeline.yml
+++ b/bootstrap/provision/refly/pipeline.yml
@@ -4,10 +4,23 @@
   debug:
     msg: "Checking pipeline {{ pipeline_stat.path | basename }} for freshness"
 
+- name: Assume invalid pipeline name
+  set_fact:
+    invalid_pipeline: true
+  when:
+    - pipeline_stat.path is defined
+
+- name: Validate pipeline name
+  set_fact:
+    invalid_pipeline: false
+  when:
+    - pipeline_stat.path is match(".*.ya?ml(?:.j2)?$")
+
 - name: Check for existing pipeline checksum
   stat:
     path: "/tmp/{{ pipeline_stat.path | basename }}.checksum"
   register: pipelines_checksum_stat
+  when: not invalid_pipeline
 
 # handle an existing pipeline checksum
 - block:
@@ -18,20 +31,25 @@
     - name: Set pipelines checksum
       set_fact: previous_checksum="{{ previous_checksum.stdout }}"
 
-  when: pipelines_checksum_stat.stat.exists
+  when:
+    - not invalid_pipeline
+    - pipelines_checksum_stat.stat.exists
 
 - name: Write to pipeline checksum
   copy:
     content: "{{ pipeline_stat.checksum }}"
     dest: "/tmp/{{ pipeline_stat.path | basename }}.checksum"
-  when: not pipelines_checksum_stat.stat.exists or
-        (pipelines_checksum_stat.stat.exists and
-         previous_checksum != pipeline_stat.checksum)
+  when:
+    - not invalid_pipeline
+    - not pipelines_checksum_stat.stat.exists or
+      (pipelines_checksum_stat.stat.exists and
+      previous_checksum != pipeline_stat.checksum)
   register: updated_file
 
 - name: Super simple check for whether the file is a pipeline definition
   shell: cat "{{ pipeline_stat.path }}" | grep -e "^jobs:$"
   when:
+    - not invalid_pipeline
     - updated_file.changed
   register: have_pipeline
   failed_when: have_pipeline.rc > 1 or have_pipeline.rc < 0
@@ -55,7 +73,9 @@
     - name: Now we have the params we need
       set_fact:
         pipeline_params: "{{ pipeline_stat.path }}"
-  when: have_pipeline.changed and have_pipeline.rc > 0 and updated_file.changed
+  when:
+    - not invalid_pipeline
+    - have_pipeline.changed and have_pipeline.rc > 0 and updated_file.changed
 
 # If we do have a pipeline, look for the matching params file.
 # The convention is {pipeline}-params.yml
@@ -67,7 +87,7 @@
       set_fact:
         expected_params: >-
           {{ pipeline_stat.path |
-             regex_replace('^(.*).yml$', '\1-params.yml') }}
+             regex_replace('^(.*).ya?ml.*$', '\1-params.yml') }}
     - name: Check for expected params by computed name
       stat:
         path: "{{ expected_params }}"
@@ -80,6 +100,41 @@
       set_fact:
         pipeline_def: "{{ pipeline_stat.path }}"
   when: have_pipeline.changed and have_pipeline.rc == 0 and updated_file.changed
+
+# This is a workaround for the fact that sequences are still evaulated even
+# when they should be skipped by "when" clause.  There's a loop in the template
+# processing below that counts down from remainder, so remainder must
+# _always_ be initialized to a numeric value for the sequence to be valid.
+- name: Set a default to avoid a dumb issue with decrementing sequence
+  set_fact:
+    remainder: 1
+
+# This block allows pipeline to be defined as jinja2 files (if pipeline ends
+# in .yml.j2 .)  If a pipeline_scale_items variable is set, we load the
+# pipeline params and look for a host var with the name that is contained in
+# pipeline_scale_items, and count those things to determine pipeline scale.
+# Pipeline scale is then used to pass in distinct ranges into the pipeline
+# template, e.g. 1..10, 11..20, etc.  This allows the pipeline to break up
+# a large number of identical deployments into a visually distinct set of
+# parallel deployments.
+- name: Check for template pipeline
+  block:
+    - name: Load pipeline variables to determine ranges
+      include_vars:
+        file: "{{ pipeline_params }}"
+    - set_fact:
+        pipeline_location: "{{ pipeline_def | dirname }}"
+        pipeline_template: "{{ pipeline_def | basename }}"
+        pipeline_scale: >-
+          {{ hostvars[inventory_hostname][pipeline_scale_items] |length |int }}
+    - import_tasks: pipeline_parallelizer.yml
+  when:
+    - not invalid_pipeline
+    - have_pipeline.changed
+    - pipeline_def is defined
+    - pipeline_params is defined
+    - pipeline_scale_items is defined
+    - pipeline_def is match(".*.ya?ml.j2$")
 
 - name: Rerun fly command
   block:
@@ -100,6 +155,9 @@
         fly -t main unpause-pipeline
         -p {{ (pipeline_def | basename | splitext)[0] }}
   when:
+    - not invalid_pipeline
     - have_pipeline.changed
     - pipeline_def is defined
     - pipeline_params is defined
+  tags:
+    - reload

--- a/bootstrap/provision/refly/pipeline_parallelizer.yml
+++ b/bootstrap/provision/refly/pipeline_parallelizer.yml
@@ -1,0 +1,69 @@
+# Copyright © 2018 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+# These tasks slice up a Concourse pipeline into parallel chunks.
+
+- name: Extract pipeline parts
+  set_fact:
+    pipeline_location: "{{ pipeline_def | dirname }}"
+    pipeline_template: "{{ pipeline_def | basename }}"
+
+- name: Initialize variables
+  set_fact:
+    ranges: []
+    range_min: 1
+    range_index: 0
+    range_extra: 0
+    remainder: 1
+
+- name: Initialize max number of ranges
+  set_fact:
+    max_ranges: 10
+  when: max_ranges is not defined
+
+# Note that we're taking the min of max_ranges and pipeline_scale, even when
+# the "when" has already guaranteed pipeline_scale is the min, because ansible
+# evaluates the sequence even when this is skipped, so it creates a super long
+# loop in the case where a large number is passed for pipeline_scale.
+- name: Explicitly use single items as ranges when small scale
+  set_fact:
+    ranges: "{{ ranges }} + [{ 'min': {{ item }}, 'max': {{ item }} }]"
+  with_sequence: start=1 end={{ [max_ranges, pipeline_scale]|min }}
+  when: "pipeline_scale|int < max_ranges"
+
+- name: Use larger block ranges when more than max_ranges
+  block:
+    - name: Set range size
+      set_fact:
+        range_size: >-
+          {{ (pipeline_scale|int / max_ranges|int) | round(0,'floor') }}
+    - name: Set remainder
+      set_fact:
+        remainder: >-
+          {{ pipeline_scale|int - (max_ranges|int * range_size|int) }}
+    - debug:
+        msg: "Range size is {{ range_size }}"
+    - set_fact:
+        range_extras: >-
+          {{ range_extras | default([]) + [1 | int] }}
+      with_sequence: start="{{ remainder|default(0) }}" end=0 stride=-1
+
+    - set_fact:
+        ranges: >-
+          {{ ranges }} + [ {
+          'min': {{ range_min|int }},
+          'max': {{ range_min|int + range_size|int - 1 + range_extras[item|int]|default(0)|int }}
+          } ]
+        range_min: "{{ range_min|int + range_size|int }}"
+        remainder: "{{ remainder|int - 1 }}"
+      with_sequence: start=1 end={{ max_ranges }}
+  when: pipeline_scale|int >= max_ranges
+
+- debug:
+    var: ranges
+
+- name: Transform pipeline for ranges of the total
+  template:
+    src: "{{ pipeline_def }}"
+    dest: "{{ pipeline_location }}/{{ (pipeline_template | splitext)[0] }}"
+  when: not ansible_check_mode

--- a/bootstrap/provision/refly/pipeline_parallelizer.yml
+++ b/bootstrap/provision/refly/pipeline_parallelizer.yml
@@ -28,7 +28,7 @@
 - name: Explicitly use single items as ranges when small scale
   set_fact:
     ranges: "{{ ranges }} + [{ 'min': {{ item }}, 'max': {{ item }} }]"
-  with_sequence: start=1 end={{ [max_ranges, pipeline_scale]|min }}
+  with_sequence: start=1 end={{ [max_ranges|int, pipeline_scale|int]|min }}
   when: "pipeline_scale|int < max_ranges"
 
 - name: Use larger block ranges when more than max_ranges

--- a/bootstrap/provision/refly/site.yml
+++ b/bootstrap/provision/refly/site.yml
@@ -15,7 +15,7 @@
         path: "{{ item }}"
         follow: True
       register: all_pipelines_stats
-      with_fileglob: "{{ pipelines_home }}/*.yml"
+      with_fileglob: "{{ pipelines_home }}/*.yml*"
       when: pipelines_stat.stat.exists
 
     - name: Iterate over pipelines


### PR DESCRIPTION
Signed-off-by: John Gardner <huxoll@gmail.com>

This adds a feature to generate some portion of the pipeline dynamically from a template.  If, rather than a pipeline yml, you instead add a yml.j2, and provide a variable named "pipeline_scale_items" that points to another variable that is a list or dict, then the "refly" automation will generate a pipeline from the template before uploading/refreshing in concourse.

The parameters sent to the template are a list of ranges, no more than 10 by default, with a lower and upper bound (min and max).  For example, with a value in the "pipeline_scale_items" variable that has 3000 items, the template will receive a structure like:
  "ranges": [
        {
            "min": 1
            "max": 300,
        },
        {
            "min": 301
            "max": 600,
        },
        {
            "min": 601
            "max": 900,
        },
        {
            "min": 901
            "max": 1200,
        },
        {
            "max": 1500,
            "min": 1201
        },
        {
            "min": 1501
            "max": 1800,
        },
        {
            "min": 1801
            "max": 2100,
        },
        {
            "min": 2101
            "max": 2400,
        },
        {
            "min": 2401
            "max": 2700,
        },
        {
            "min": 2701
            "max": 3000,
        }
    ]