### PR TITLE
Fix an incorrect range boundary; generate file to tmp.

### DIFF
--- a/bootstrap/provision/concourse.yml
+++ b/bootstrap/provision/concourse.yml
@@ -62,5 +62,5 @@
           cd $HOME/refly &&
           ansible-playbook -i inventory site.yml
           -e "@extra_vars.yml"
-          -vv >> refly.lastlog 2>&1
+          >> refly.log 2>&1 && savelog -q -p -c 30 refly.log
         user: "{{ deploy_user }}"

--- a/bootstrap/provision/refly/pipeline.yml
+++ b/bootstrap/provision/refly/pipeline.yml
@@ -70,6 +70,16 @@
       set_fact:
         pipeline_def: "{{ expected_pipeline }}"
       when: now_have_pipeline is defined and now_have_pipeline.stat.exists
+    - name: No pipeline yet, check for template
+      stat:
+        path: "{{ expected_pipeline }}.j2"
+      register: now_have_pipeline_template
+    - name: Now we have the (template) pipeline we need
+      set_fact:
+        pipeline_def: "{{ expected_pipeline }}.j2"
+      when:
+        - now_have_pipeline_template is defined
+        - now_have_pipeline_template.stat.exists
     - name: Now we have the params we need
       set_fact:
         pipeline_params: "{{ pipeline_stat.path }}"

--- a/bootstrap/provision/refly/pipeline_parallelizer.yml
+++ b/bootstrap/provision/refly/pipeline_parallelizer.yml
@@ -54,7 +54,9 @@
           'min': {{ range_min|int }},
           'max': {{ range_min|int + range_size|int - 1 + range_extras[item|int]|default(0)|int }}
           } ]
-        range_min: "{{ range_min|int + range_size|int }}"
+        range_min: >-
+          {{ range_min|int + range_size|int +
+          range_extras[item|int]|default(0)|int }}
         remainder: "{{ remainder|int - 1 }}"
       with_sequence: start=1 end={{ max_ranges }}
   when: pipeline_scale|int >= max_ranges
@@ -62,8 +64,28 @@
 - debug:
     var: ranges
 
+- debug:
+    var: pipeline_params
+
+- name: Set config version
+  block:
+    - command: date "+%Y%m%d%H%M%S"
+      register: datestamp
+    - set_fact:
+        config_version: "-{{ datestamp.stdout }}"
+  when: config_version is undefined
+
+- debug:
+    var: config_version
+  when: config_version is defined
+
 - name: Transform pipeline for ranges of the total
   template:
     src: "{{ pipeline_def }}"
-    dest: "{{ pipeline_location }}/{{ (pipeline_template | splitext)[0] }}"
+    dest: "/tmp/{{ (pipeline_template | splitext)[0] }}"
   when: not ansible_check_mode
+
+- name: Set pipeline name to processed file.
+  set_fact:
+    pipeline_def: >-
+      /tmp/{{ (pipeline_template | splitext)[0] }}


### PR DESCRIPTION
This fixes some defects.

- A remainder after distributing items across the pipeline wasn't indexed correctly
- Generating the yml into the pipelines directory would cause it to be reloaded, defeating the template step, now we template into /tmp.